### PR TITLE
fix: 이미지 업로드 관련하여 서버에서 s3설정 삭제

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,10 +5,6 @@ const mongoose = require("mongoose");
 const cors = require("cors");
 require("dotenv").config();
 
-const AWS = require("aws-sdk");
-const multer = require("multer");
-const multerS3 = require("multer-s3");
-
 const login = require("./routes/loginRoutes");
 const presentation = require("./routes/presentationRoutes");
 const slide = require("./routes/slideRoutes");
@@ -25,19 +21,9 @@ app.use(express.urlencoded({ extended: false }));
 app.use(logger("dev"));
 app.use(cors(config.cors));
 
-const s3 = new AWS.S3(config.aws);
-
-const upload = multer({
-  storage: multerS3({
-    s3,
-    bucket: config.multer.bucket,
-    key: config.multer.key,
-  }),
-});
-
 app.use(config.routes.login, login);
 app.use(config.routes.presentation, presentation);
-app.use(config.routes.slide, upload.single("image"), slide);
+app.use(config.routes.slide, slide);
 app.use(config.routes.object, object);
 app.use(config.routes.animation, animation);
 

--- a/configs/appConfig.js
+++ b/configs/appConfig.js
@@ -5,17 +5,6 @@ module.exports = {
   cors: {
     origin: process.env.CORS_ORIGIN,
   },
-  aws: {
-    region: process.env.AWS_REGION || "ap-northeast-2",
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  },
-  multer: {
-    bucket: process.env.AWS_S3_BUCKET || "peachpitch",
-    key: (req, file, cb) => {
-      cb(null, Date.now().toString());
-    },
-  },
   routes: {
     login: "/login",
     presentation: "/users/:user_id/presentations",

--- a/controllers/objectController.js
+++ b/controllers/objectController.js
@@ -11,13 +11,13 @@ async function createObject(req, res, next) {
     dimensions: { height: 100, width: 100 },
     boundaryVertices: [
       { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 100, y: 100 },
-      { x: 0, y: 100 },
-      { x: 100, y: 100 },
-      { x: 100, y: 50 },
-      { x: 100, y: 0 },
       { x: 50, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 50 },
+      { x: 100, y: 100 },
+      { x: 50, y: 100 },
+      { x: 0, y: 100 },
+      { x: 0, y: 50 },
     ],
     animation: {},
   };
@@ -60,7 +60,7 @@ async function createObject(req, res, next) {
       break;
     case "Image":
       defaultObjectProperties.Image = {
-        imageUrl: req.file ? req.file.location : "",
+        imageUrl: "",
         borderColor: "#000000",
       };
       break;


### PR DESCRIPTION
## 개요
이미지 업로드 관련하여 서버에서 s3설정 삭제

## 작업사항
- 서버에서 s3설정 삭제
- 클라이언트와 s3가 바로 통신 할 수 있도록 프론트단에서 s3 세팅 예정. 이용자는 효율적으로 이미지 업로드를 할 수 있고, 서버의 부담을 줄임.
- 이미지 관련 업데이트는 별도로 처리 (드래그, 크기)

## 변경로직
- 없음