### PR TITLE
fix: 클라이언트에서 이미지 url 가져오기

### DIFF
--- a/controllers/objectController.js
+++ b/controllers/objectController.js
@@ -47,8 +47,8 @@ async function createObject(req, res, next) {
         borderColor: "#000000",
       };
       break;
-    case "TextBox":
-      defaultObjectProperties.TextBox = {
+    case "Textbox":
+      defaultObjectProperties.Textbox = {
         content: "New Textbox",
         fontSize: 14,
         textAlign: "left",
@@ -93,6 +93,34 @@ async function createObject(req, res, next) {
       result: "success",
       message: "Object successfully created",
       object: defaultObjectProperties,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function getAllObjects(req, res, next) {
+  const { presentation_id, slide_id } = req.params;
+
+  try {
+    const presentation = await Presentation.findById(presentation_id);
+    if (!presentation) {
+      return res
+        .status(404)
+        .json({ result: "error", message: "Presentation not found" });
+    }
+
+    const slide = presentation.slides.id(slide_id);
+    if (!slide) {
+      return res
+        .status(404)
+        .json({ result: "error", message: "Slide not found" });
+    }
+
+    res.json({
+      result: "success",
+      message: "Objects successfully retrieved",
+      objects: slide.objects,
     });
   } catch (err) {
     next(err);
@@ -255,6 +283,7 @@ async function updateObjectZindex(req, res, next) {
 module.exports = {
   createObject,
   getObject,
+  getAllObjects,
   updateObject,
   deleteObject,
   updateObjectZindex,

--- a/controllers/objectController.js
+++ b/controllers/objectController.js
@@ -3,7 +3,7 @@ const Presentation = require("../models/Presentation");
 
 async function createObject(req, res, next) {
   const { presentation_id, slide_id } = req.params;
-  const { type } = req.body;
+  const { type, imageUrl } = req.body;
   const defaultObjectProperties = {
     objectId: new mongoose.Types.ObjectId(),
     type,
@@ -60,7 +60,7 @@ async function createObject(req, res, next) {
       break;
     case "Image":
       defaultObjectProperties.Image = {
-        imageUrl: "",
+        imageUrl,
         borderColor: "#000000",
       };
       break;

--- a/models/Object.js
+++ b/models/Object.js
@@ -3,7 +3,7 @@ const mongoose = require("mongoose");
 const ObjectSchema = new mongoose.Schema({
   type: {
     type: String,
-    enum: ["Circle", "Triangle", "Square", "TextBox", "Image"],
+    enum: ["Circle", "Triangle", "Square", "Textbox", "Image"],
     required: true,
   },
   coordinates: {

--- a/routes/objectRoutes.js
+++ b/routes/objectRoutes.js
@@ -3,13 +3,14 @@ const express = require("express");
 const router = express.Router({ mergeParams: true });
 const {
   getObject,
+  getAllObjects,
   createObject,
   updateObject,
   deleteObject,
   updateObjectZindex,
 } = require("../controllers/objectController");
 
-router.route("/").post(createObject).put(updateObjectZindex);
+router.route("/").get(getAllObjects).post(createObject).put(updateObjectZindex);
 
 router
   .route("/:object_id")


### PR DESCRIPTION
## 개요
클라이언트에서 이미지 url 가져오기

## 작업사항
- 클라이언트에서 이미지 업로드 했을 경우 (amazon s3에 저장 시), 생성되는 url을 서버가 가져오고 db에 저장되도록 수정

## 브랜치에 추가된 작업
- objectController에 getAllObjects추가, routes에 get추가
- 스키마 object type : "TextBox"에서 "Textbox"로 수정

## 변경로직
- 없음
