### PR TITLE
fix: unify to fillColor

### DIFF
--- a/models/Object.js
+++ b/models/Object.js
@@ -82,7 +82,7 @@ const TextBoxSchema = new mongoose.Schema(
       enum: ["normal", "bold", "italic", "underline", "strikeThrough"],
       default: ["normal"],
     },
-    innerColor: { type: String, default: "#000000" },
+    fillColor: { type: String, default: "#000000" },
     borderColor: { type: String, default: "#000000" },
   },
   { _id: false },


### PR DESCRIPTION
## 개요
Textbox의 innerColor 를 fillColor로 변경

## 작업사항
- Textbox의 innerColor 를 fillColor로 변경
- 이미지를 제외한 나머지 객체는 fillColor를 속성으로 가짐

## 변경로직
- 없음
