### PR TITLE
fix: object delete method

### DIFF
--- a/controllers/objectController.js
+++ b/controllers/objectController.js
@@ -203,7 +203,11 @@ async function deleteObject(req, res, next) {
       animation => animation.objectId.toString() !== object_id,
     );
 
-    slide.objects.pull(object_id);
+    slide.objects = slide.objects.map(obj =>
+      obj._id.toString() === object_id ? null : obj,
+    );
+
+    slide.objects = slide.objects.filter(obj => obj !== null);
 
     await presentation.save();
     res.json({

--- a/controllers/objectController.js
+++ b/controllers/objectController.js
@@ -196,10 +196,14 @@ async function deleteObject(req, res, next) {
         .json({ result: "error", message: "Object not found" });
     }
 
-    slide.objects.pull(object_id);
+    slide.zIndexSequence = slide.zIndexSequence.filter(
+      id => id.toString() !== object_id,
+    );
+    slide.animationSequence = slide.animationSequence.filter(
+      animation => animation.objectId.toString() !== object_id,
+    );
 
-    slide.zIndexSequence = slide.zIndexSequence.filter(id => id !== object_id);
-    slide.animationSequence = slide.animationSequence.filter(id => id !== object_id);
+    slide.objects.pull(object_id);
 
     await presentation.save();
     res.json({


### PR DESCRIPTION
## 개요
오른쪽 클릭시 나타나는 메뉴 창을 통해 객체를 삭제하는 기능

## 작업사항
객체를 삭제할 때, slide.zIndexSequence 배열과 slide.AminationSequence 배열에서 해당 객체의 id와 같은 요소가 삭제되지 않는 문제
animation order가 사라지지 않아, 에러가 발생

### z index 배열
mongoose Object id 를 단순 비교하다가 생긴 문제 (moongoose Id는 String으로 바꿔준 뒤 비교한다)

[수정 전 코드] 
 `slide.zIndexSequence = slide.zIndexSequence.filter(id => id !== object_id);`
[수정 후 코드]
```
slide.zIndexSequence = slide.zIndexSequence.filter(
      id => id.toString() !== object_id,
    );
```

### animation 배열
animation 배열은 배열 안에 객체들로 구성되어있다. key 중의 하나인 "ObjectId" 와 삭제된 객체의 id가 같은 필드를 삭제해야한다. 
[수정 전 코드]
`slide.animationSequence` = slide.animationSequence.filter(id => id !== object_id);

[수정 후 코드]
```
    slide.animationSequence = slide.animationSequence.filter(
      animation => animation.objectId.toString() !== object_id,
    );
```

## 변경로직
```
    slide.zIndexSequence = slide.zIndexSequence.filter(
      id => id.toString() !== object_id,
    );
    slide.animationSequence = slide.animationSequence.filter(
      animation => animation.objectId.toString() !== object_id,
    );

    slide.objects.pull(object_id);

    await presentation.save();
```
